### PR TITLE
一覧画面から名前欄を削除

### DIFF
--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -20,7 +20,6 @@
       <tr>
         <td><%= board.id %></td>
         <td><%= board.title %></td>
-        <td><%= board.name %></td>
         <td><%= board.created_at.to_s(:datetime_jp) %></td>
         <td><%= board.updated_at.to_s(:datetime_jp) %></td>
         <td><%= link_to '詳細', board, class: 'btn btn-outline-dark' %></td>


### PR DESCRIPTION
現時点では個人利用を考えているため、一旦、一覧画面から名前欄を削除した。