### PR TITLE
入力フォームから名前入力を削除

### DIFF
--- a/app/views/boards/_form.html.erb
+++ b/app/views/boards/_form.html.erb
@@ -1,9 +1,5 @@
 <%= form_for board do |f| %>
   <div class ="form-group">
-    <%= f.label :name, '名前' %>
-    <%= f.text_field :name, class: 'form-control' %>
-  </div>
-  <div class ="form-group">
     <%= f.label :title, 'タイトル' %>
     <%= f.text_field :title, class: 'form-control' %>
   </div>


### PR DESCRIPTION
現時点では個人利用を考えているため、一旦、入力フォームから名前入力を削除した。