### PR TITLE
facebookとtwitterのログイン機能を一旦保留

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,8 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'pry-byebug'
   gem 'devise'
-  gem 'omniauth-facebook'
-  gem 'omniauth-twitter'
+  # gem 'omniauth-facebook'
+  # gem 'omniauth-twitter'
   gem 'omniauth-google-oauth2'
   gem 'dotenv-rails'
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,14 +1,14 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
-  # callback for facebook
-  def facebook
-    callback_for(:facebook)
-  end
+  # # callback for facebook
+  # def facebook
+  #   callback_for(:facebook)
+  # end
 
-  # callback for twitter
-  def twitter
-    callback_for(:twitter)
-  end
+  # # callback for twitter
+  # def twitter
+  #   callback_for(:twitter)
+  # end
 
   # callback for google
   def google_oauth2

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i[facebook twitter google_oauth2]
+         :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i[google_oauth2]
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.email = auth.info.email

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -308,8 +308,8 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true]
-  config.omniauth :facebook, ENV['FACEBOOK_KEY'], ENV['FACEBOOK_SECRET'], scope: 'email', info_fields: 'email', callback_url: "#{ENV['HOST']}/users/auth/facebook/callback"
-  config.omniauth :twitter, ENV['TWITTER_API_KEY'], ENV['TWITTER_API_SECRET'], scope: 'email', oauth_callback: "#{ENV['HOST']}/users/auth/twitter/callback"
+  # config.omniauth :facebook, ENV['FACEBOOK_KEY'], ENV['FACEBOOK_SECRET'], scope: 'email', info_fields: 'email', callback_url: "#{ENV['HOST']}/users/auth/facebook/callback"
+  # config.omniauth :twitter, ENV['TWITTER_API_KEY'], ENV['TWITTER_API_SECRET'], scope: 'email', oauth_callback: "#{ENV['HOST']}/users/auth/twitter/callback"
   config.omniauth :google_oauth2,ENV['GOOGLE_CLIENT_ID'],ENV['GOOGLE_CLIENT_SECRET']
   OmniAuth.config.logger = Rails.logger if Rails.env.development?
 end


### PR DESCRIPTION
Google, Facebook, Twitterのアカウント認証機能を一気にすべて実装しようとしてしまったので、facebookとtwitterのログイン機能を一旦保留にした。