### PR TITLE
アプリの名前を変更

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>HelpsToStudy</title>
+    <title>Language Bank</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 


### PR DESCRIPTION
アプリの名前を、Helps to StudyからLanguage Bankに変更