### PR TITLE
ログイン時のみナビバーにマイページを表示するよう変更

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -7,9 +7,6 @@
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
       <li class="nav-item active">
-        <a href="/users/<%= current_user.id %>" class="nav-link">マイページ</a>
-      </li>
-      <li class="nav-item active">
         <%= link_to '管理者', new_admin_user_session_path, class: 'nav-link' %>
       </li>
       <li class="nav-item active">
@@ -17,6 +14,9 @@
       </li>
       <li class="nav-item">
         <% if user_signed_in? %>
+          <li class="nav-item active">
+            <a href="/users/<%= current_user.id %>" class="nav-link">マイページ</a>
+          </li>
           <li class="nav-item active">
             <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'nav-link' %>
           </li>


### PR DESCRIPTION
ナビバーに記載したマイページのリンクが原因で、ログアウトするとエラーによりアプリが開けなくなる事象を確認した。
ログイン時のみマイページリンクをナビバーに出現させるように変更し、エラーを解消した。